### PR TITLE
Don't throw an error when no prefix can be found

### DIFF
--- a/company-ghci.el
+++ b/company-ghci.el
@@ -59,9 +59,11 @@
 
 (defun company-ghci/can-complete-p ()
   (and (haskell-session-maybe)
-       (cl-destructuring-bind
-	   (beg end prefix type) (haskell-completions-grab-prefix)
-	 prefix)))
+       (let ((prefix-info (haskell-completions-grab-prefix)))
+         (when prefix-info
+           (cl-destructuring-bind
+               (beg end prefix type) prefix-info
+             prefix)))))
 
 ;;;###autoload
 (defun company-ghci (command &optional arg &rest ignored)


### PR DESCRIPTION
haskell-completions-grab-prefix returns nil when there's no prefix,
which ripples an error up to the user level. This patch detects this
failure and returns nil in order to work smoothly with company.
