### PR TITLE
Handle nil return values from haskell-completions-sync-completions-at-point

### DIFF
--- a/company-ghci.el
+++ b/company-ghci.el
@@ -52,10 +52,12 @@
   (company-ghci/repl-command (concat ":t " function)))
 
 (defun company-ghci/get-completions (to-complete)
-  (cl-destructuring-bind
-      (beg end completions) (haskell-completions-sync-completions-at-point)
-    (cl-remove-if-not (lambda (candidate) (string-match to-complete candidate))
-		      completions)))
+  (let ((completion-info (haskell-completions-sync-completions-at-point)))
+    (when completion-info
+      (cl-destructuring-bind
+          (beg end completions) completion-info
+        (cl-remove-if-not (lambda (candidate) (string-prefix-p to-complete candidate))
+                          completions)))))
 
 (defun company-ghci/can-complete-p ()
   (and (haskell-session-maybe)


### PR DESCRIPTION
This commit also uses `string-prefix-p` in place of `string-match`,
which should avoid problems when `to-complete` is not a valid
regexp -- this shouldn't be a regexp match at all, in fact.
