### PR TITLE
Suppress byte-compile warnings about unused variable

### DIFF
--- a/company-ghci.el
+++ b/company-ghci.el
@@ -55,7 +55,7 @@
   (let ((completion-info (haskell-completions-sync-completions-at-point)))
     (when completion-info
       (cl-destructuring-bind
-          (beg end completions) completion-info
+          (_beg _end completions) completion-info
         (cl-remove-if-not (lambda (candidate) (string-prefix-p to-complete candidate))
                           completions)))))
 
@@ -64,7 +64,7 @@
        (let ((prefix-info (haskell-completions-grab-prefix)))
          (when prefix-info
            (cl-destructuring-bind
-               (beg end prefix type) prefix-info
+               (_beg _end prefix _type) prefix-info
              prefix)))))
 
 ;;;###autoload


### PR DESCRIPTION
This patch fixes following byte-compile warnings.

```
Entering directory `/home/syohei/company-ghci/'
company-ghci.el:54:1:Warning: Unused lexical variable `end'
company-ghci.el:54:1:Warning: Unused lexical variable `beg'
company-ghci.el:62:1:Warning: Unused lexical variable `type'
company-ghci.el:62:1:Warning: Unused lexical variable `end'
company-ghci.el:62:1:Warning: Unused lexical variable `beg'
```
