### PR TITLE
Wrap symbols with double quotes when calling hoogle for info

### DIFF
--- a/company-ghci.el
+++ b/company-ghci.el
@@ -37,7 +37,7 @@
 (defun company-ghci/hoogle-info (symbol)
   "Use hoogle --info to search documentation of SYMBOL"
   (when (executable-find "hoogle")
-    (shell-command-to-string (format "hoogle --info %s" symbol))))
+    (shell-command-to-string (format "hoogle --info \"%s\"" symbol))))
 
 (defun company-ghci/repl-command (cmd)
   "Execute CMD in the ghci process."


### PR DESCRIPTION
This is necessary to lookup symbols containing single quotes (e.g. foldl').

Thanks for writing this plugin, works great! :D